### PR TITLE
Fix menu button vertical alignment by restoring header link padding

### DIFF
--- a/web/src/components/Layout/Header/Header.js
+++ b/web/src/components/Layout/Header/Header.js
@@ -33,7 +33,7 @@ const Header = ({ name = "Missing name", navItems }) => {
         <Link
           href={urls.pages.index()}
           title={name}
-          className="block py-2 px-0 lg:!py-3 lg:!px-2 text-title2"
+          className="block py-3 px-2 lg:!py-3 lg:!px-0 text-title2"
         >
           {name}
         </Link>


### PR DESCRIPTION
The SCSS-to-Tailwind migration changed the header title link's padding
from 12px (original mobile value) to 8px (py-2), shrinking the header
height. This caused the fixed-position sidebar menu button — centered at
~45px from the viewport top — to sit at the very bottom edge of the
header instead of being contained within it.

Restores py-3 (12px) vertical and px-2 (8px) horizontal padding on
mobile/tablet to match the original SCSS `padding: 12px 8px` rule
(breakpoint-below-large). Also corrects lg desktop horizontal padding
to px-0 (was px-2, original was 0).

https://claude.ai/code/session_01DR3M8sLyYzZdPbpp3vA4YB